### PR TITLE
Remove Openmailbox from email providers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,20 +1051,6 @@
 			<tbody>
 
 				<tr>
-					<td data-value="OpenMailBox">
-						<a href="https://www.openmailbox.org/"><img src="img/provider/OpenMailBox.gif" width="200" height="70">
-							<br />OpenMailBox.org</a>
-					</td>
-					<td data-value="2013">2013</td>
-					<td><span class="flag-icon flag-icon-fr"></span> France</td>
-					<td data-value="1000">1 GB</td>
-					<td data-value="0"><span class="label label-warning">Free</span></td>
-					<td data-value="1"><span class="label label-success">Accepted</span></td>
-					<td data-value="1"><span class="label label-success">Built-in</span></td>
-					<td data-value="0"><span class="label label-primary">No</span></td>
-				</tr>
-
-				<tr>
 					<td data-value="ProtonMail">
 						<a href="https://www.protonmail.ch/"><img src="img/provider/ProtonMail.ch.gif" width="200" height="70">
 							<br />ProtonMail.ch</a>


### PR DESCRIPTION
Service is dying. List of issues copied from [RIP openmailbox forum topic](https://forum.openmailbox.org/viewtopic.php?id=1747)

- SSL certificate for forum expired on Wednesday, December 28, 2016 (hopefully, for webmail it will expire on Thursday, November 16, 2017)
- new registrations still not available (!);
- writting to support@openmailbox.org won't help you to create new account;
- Support was online almost two months ago;
- Outlook Mail doesn't receive my emails;
- XMPP stopped working;
- new version still not ready;
- source code still not published;
- permanent problems with receiving some emails.
- Can't use third party programs like K9-Mail and Thunderbird because of connection timout problems all the time.
- Still all mails are saved in one encrypted volume which the owner has complete acess to and of course authorities if they like